### PR TITLE
Update domain plot

### DIFF
--- a/R/annoFuse_single_sample.R
+++ b/R/annoFuse_single_sample.R
@@ -74,7 +74,7 @@ annoFuse_single_sample <- function(fusionfileArriba = fusionfileArriba,
 
   # if StarFusion file is empty only run standardization for Arriba calls
   if (is_empty(STARFusioninputfile$FusionName) & !is_empty(Arribainputfile$"gene1--gene2")) {
-    warning(paste("No fusion calls in StarFusion : ", opt$fusionfileStarFusion))
+    warning(paste("No fusion calls in StarFusion "))
 
     colnames(Arribainputfile)[27] <- "annots"
     # To have a general column with unique IDs associated with each sample
@@ -90,7 +90,7 @@ annoFuse_single_sample <- function(fusionfileArriba = fusionfileArriba,
 
   # if Arriba file is empty only run standardization for StarFusion calls
   if (!is_empty(STARFusioninputfile$FusionName) & is_empty(Arribainputfile$"gene1--gene2")) {
-    warning(paste("No fusion calls in StarFusion : ", opt$fusionfileStarFusion))
+    warning(paste("No fusion calls in Arriba "))
 
     # To have a general column with unique IDs associated with each sample
     STARFusioninputfile$Sample <- tumorID

--- a/R/annoFuse_single_sample.R
+++ b/R/annoFuse_single_sample.R
@@ -19,7 +19,23 @@
 #' @return Standardized fusion calls annotated with gene list and fusion list provided in reference folder
 #'
 #' @examples
-#' # TODOTODO
+#' standardFusioncalls <- annoFuse::annoFuse_single_sample(
+#'   # Example files are provided in extdata, at-least 1 fusionfile is required along with it's rsem expression file
+#'   fusionfileArriba = system.file("extdata", "arriba_example.tsv", package = "annoFuse"),
+#'   fusionfileStarFusion = system.file("extdata", "starfusion_example.tsv", package = "annoFuse"),
+#'   expressionFile = system.file("extdata", "example.rsem.genes.results.gz", package = "annoFuse"),
+#'   tumorID = "BS_W97QQYKQ",
+#'   # multiple read flag values for filtering using FusionAnnotator values
+#'   artifactFilter = "GTEx_Recurrent|DGD_PARALOGS|Normal|BodyMap|ConjoinG",
+#'   # keep all in-frame , frameshift and other types of Fusion_Type
+#'   readingFrameFilter = "in-frame|frameshift|other",
+#'   # keep all fusions with atleast 1 junction read support
+#'   junctionReadCountFilter = 1,
+#'   # keep only fusions where spanningFragCount-junctionReadCountFilter less than equal to 10
+#'   spanningFragCountFilter = 10,
+#'   # keep read throughs
+#'   readthroughFilter = FALSE
+#' )
 annoFuse_single_sample <- function(fusionfileArriba = fusionfileArriba,
                                    fusionfileStarFusion = fusionfileStarFusion,
                                    expressionFile = NULL,

--- a/R/plot_breakpoints.R
+++ b/R/plot_breakpoints.R
@@ -3,7 +3,7 @@
 #' @param domainDataFrame A dataframe from star fusion or arriba standardized to run through the filtering steps and get_Pfam_domain() function to get pfam domain annotation per gene
 #' @param exons exon level information from gtf availbale in the package exonsToPlot.RDS
 #' @param geneposition Position of gene in the fusion allowed values are Left (Gene1A) or Right (Gene1B)
-#' @param sampleid id from Sample column of standardized fusion file format 
+#' @param sampleid id (if multiple provide a character vector) from Sample column of standardized fusion file format 
 #' @param fusionname value from FusionName column of standardized fusion file format (Gene1A--Gene1B) 
 #' @param leftBreakpoint If a specific breakpoint needs to be plotted then provide genomic coordinate as LeftBreakpoint 
 #' @param rightBreakpoint  If a specific breakpoint needs to be plotted then provide genomic coordinate as RightBreakpoint
@@ -49,8 +49,8 @@ plot_breakpoints <- function(domainDataFrame = NULL,
   } 
   
   if (!is.null(sampleid) ){
-    domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$Sample == sampleid), ] 
-    domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$Sample == sampleid), ] 
+    domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$Sample %in% sampleid), ] 
+    domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$Sample %in% sampleid), ] 
   }
 
   if (!is.null(leftBreakpoint)){

--- a/R/plot_breakpoints.R
+++ b/R/plot_breakpoints.R
@@ -1,24 +1,76 @@
 #' Function to plot breakpoints of a gene in a sample/cohort
 
 #' @param domainDataFrame A dataframe from star fusion or arriba standardized to run through the filtering steps and get_Pfam_domain() function to get pfam domain annotation per gene
-#' @param exons exon level information from gtf
-#' @param geneposition Left/Right position of gene
+#' @param exons exon level information from gtf availbale in the package exonsToPlot.RDS
+#' @param geneposition Position of gene in the fusion allowed values are Left (Gene1A) or Right (Gene1B)
+#' @param sampleid id from Sample column of standardized fusion file format 
+#' @param fusionname value from FusionName column of standardized fusion file format (Gene1A--Gene1B) 
+#' @param leftBreakpoint If a specific breakpoint needs to be plotted then provide genomic coordinate as LeftBreakpoint 
+#' @param rightBreakpoint  If a specific breakpoint needs to be plotted then provide genomic coordinate as RightBreakpoint
+#' @param base_size base size for text in plot ; default is 12
 #'
 #' @export
 #'
 #' @return ggplot of gene and breakpoints
 #'
 #' @examples
-#' # TODOTODO
-plot_breakpoints <- function(domainDataFrame = domainDataFrame,
+#' standardFusionfile <- system.file("extdata", "PutativeOncogenicFusion.tsv", package = "annoFuse")
+#' standardFusioncalls <- readr::read_tsv(standardFusionfile)
+#' exons <- readRDS(system.file("extdata", "exonsToPlot.RDS", package = "annoFuse"))
+#' bioMartDataPfam <- readRDS(system.file("extdata", "pfamDataBioMart.RDS", package = "annoFuse"))
+#' domainDataFrame <- get_Pfam_domain(standardFusioncalls = standardFusioncalls, bioMartDataPfam = bioMartDataPfam, keepPartialAnno = TRUE)
+#' left <- plot_breakpoints(sampleid = "BS_044XZ8ST",domainDataFrame = domainDataFrame,exons = exons,geneposition = "Left",fusionname = "ANTXR1--BRAF")
+#' right <- plot_breakpoints(sampleid = "BS_044XZ8ST",domainDataFrame = domainDataFrame,exons = exons,geneposition = "Right",fusionname = "ANTXR1--BRAF")
+#' ggpubr::ggarrange(left,right,align = "h")
+#' 
+#' 
+plot_breakpoints <- function(domainDataFrame = NULL,
                              exons = exons,
-                             geneposition = geneposition) {
+                             geneposition = NULL,
+                             sampleid = NULL,
+                             fusionname = NULL,
+                             leftBreakpoint = NULL ,
+                             rightBreakpoint = NULL,
+                             base_size = 12 ) {
+  if( is.null(domainDataFrame)){
+    stop("domainDataFrame not provide; please provide output from get_Pfam_domain() ")
+  } else {
+    
+  if ( is.null(fusionname) ){
+    warning("FusionName not provide; using first row of domainDataFrame")
+  } else {
+    # subset the dataframe with domain information to only fusionname
+  domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$FusionName == fusionname), ] 
+  domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$FusionName == fusionname), ]
+  }
+    
+  if(nrow(domainDataFrame$Gene1B)==0 | nrow(domainDataFrame$Gene1A)==0 ) {
+    stop("domainDataFrame is empty after selecting for fusionname ")
+  } 
+  
+  if (!is.null(sampleid) ){
+    domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$Sample == sampleid), ] 
+    domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$Sample == sampleid), ] 
+  }
+
+  if (!is.null(leftBreakpoint)){
+    domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$LeftBreakpoint == leftBreakpoint), ] 
+  }
+  if (!is.null(rightBreakpoint)){
+    domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$RightBreakpoint == rightBreakpoint), ] 
+  }
+
+  }
+  
+  if (base_size != 12 ){
+    base_size <- base_size
+  }
 
   # find unique
   if (geneposition == "Left") {
-    geneExons <- exons[which(exons$geneName %in% unique(domainDataFrame$Gene1A)), ]
+    geneExons <- exons[which(exons$geneName %in% unique(domainDataFrame$Gene1A$Gene1A)), ]
     # merge domain and exon annotation to plot
-    geneExons <- geneExons %>% left_join(domainDataFrame, by = c("geneName" = "Gene1A"))
+    geneExons <- geneExons %>% left_join(domainDataFrame$Gene1A, by = c("geneName" = "Gene1A"))
     # rename transcript column for gene
     geneExons[grep("gene", geneExons$type), "transcript"] <- geneExons[grep("gene", geneExons$type), "geneName"]
     # get gene name
@@ -30,20 +82,21 @@ plot_breakpoints <- function(domainDataFrame = domainDataFrame,
     geneExons$transcript <- factor(geneExons$transcript, levels = uniqtranscript[length(uniqtranscript):1])
     # basic plot for exon and gene
     p1 <- ggplot(geneExons, aes(y = geneExons$start, x = geneExons$transcript)) +
-      geom_hline(yintercept = as.numeric(domainDataFrame$LeftBreakpoint), linetype = "dashed", color = "violet") +
+      geom_hline(yintercept = as.numeric(domainDataFrame$Gene1A$LeftBreakpoint), linetype = "dashed", color = "violet") +
       geom_linerange(ymin = geneExons$start, ymax = geneExons$end, size = 3) +
       geom_linerange(ymin = geneExons$start, ymax = geneExons$end, size = 6, aes(col = geneExons$DESC, x = gene), color = "grey") +
       coord_flip() +
-      theme_publication() +
+      theme_publication(base_size = base_size) +
       xlab("Transcript") +
       ylab("Coordinate") +
       ggtitle(paste0(geneposition, " fused Gene:", gene)) +
       labs(fill = "Domain")
   }
+  
   if (geneposition == "Right") {
-    geneExons <- exons[which(exons$geneName %in% unique(domainDataFrame$Gene1B)), ]
+    geneExons <- exons[which(exons$geneName %in% unique(domainDataFrame$Gene1B$Gene1B)), ]
     # merge domain and exon annotation to plot
-    geneExons <- geneExons %>% left_join(domainDataFrame, by = c("geneName" = "Gene1B"))
+    geneExons <- geneExons %>% left_join(domainDataFrame$Gene1B, by = c("geneName" = "Gene1B"))
     # rename transcript column for gene
     geneExons[grep("gene", geneExons$type), "transcript"] <- geneExons[grep("gene", geneExons$type), "geneName"]
     # get gene name
@@ -55,20 +108,21 @@ plot_breakpoints <- function(domainDataFrame = domainDataFrame,
     geneExons$transcript <- factor(geneExons$transcript, levels = uniqtranscript[length(uniqtranscript):1])
     # basic plot for exon and gene
     p1 <- ggplot(geneExons, aes(y = geneExons$end, x = geneExons$transcript)) +
-      geom_hline(yintercept = as.numeric(domainDataFrame$RightBreakpoint), linetype = "dashed", color = "violet") +
+      geom_hline(yintercept = as.numeric(domainDataFrame$Gene1B$RightBreakpoint), linetype = "dashed", color = "violet") +
       geom_linerange(ymin = geneExons$start, ymax = geneExons$end, size = 3) +
       geom_linerange(ymin = geneExons$start, ymax = geneExons$end, size = 6, aes(col = geneExons$DESC, x = gene), color = "grey") +
       coord_flip() +
-      theme_publication() +
+      theme_publication(base_size = base_size) +
       xlab("Transcript") +
       ylab("Coordinate") +
       ggtitle(paste0(geneposition, " fused Gene:", gene))
   }
 
   # add domain level information
-  if (any(!is.na(geneExons$DESC))) {
-    p1 <- p1 + geom_linerange(ymin = geneExons$domain_start, ymax = geneExons$domain_end, size = 6, aes(col = geneExons$DESC, x = gene)) + labs(color = "Domain")
-  }
+  if (!all(is.na(geneExons$DESC))) {
+    p1 <- p1 + geom_linerange(ymin = geneExons$domain_start, ymax = geneExons$domain_end, size = 6, aes(col = geneExons$DESC, x = gene)) + labs(color = "Domain") +theme(legend.position = "bottom") + 
+      ggplot2::scale_colour_discrete(na.translate = F)
+  }  
 
   # add direction of strand
   if (any(geneExons$strand.x == "+")) {
@@ -78,4 +132,5 @@ plot_breakpoints <- function(domainDataFrame = domainDataFrame,
   }
 
   return(p2)
+  
 }

--- a/R/plot_breakpoints.R
+++ b/R/plot_breakpoints.R
@@ -3,9 +3,9 @@
 #' @param domainDataFrame A dataframe from star fusion or arriba standardized to run through the filtering steps and get_Pfam_domain() function to get pfam domain annotation per gene
 #' @param exons exon level information from gtf availbale in the package exonsToPlot.RDS
 #' @param geneposition Position of gene in the fusion allowed values are Left (Gene1A) or Right (Gene1B)
-#' @param sampleid id (if multiple provide a character vector) from Sample column of standardized fusion file format 
-#' @param fusionname value from FusionName column of standardized fusion file format (Gene1A--Gene1B) 
-#' @param leftBreakpoint If a specific breakpoint needs to be plotted then provide genomic coordinate as LeftBreakpoint 
+#' @param sampleid id (if multiple provide a character vector) from Sample column of standardized fusion file format
+#' @param fusionname value from FusionName column of standardized fusion file format (Gene1A--Gene1B)
+#' @param leftBreakpoint If a specific breakpoint needs to be plotted then provide genomic coordinate as LeftBreakpoint
 #' @param rightBreakpoint  If a specific breakpoint needs to be plotted then provide genomic coordinate as RightBreakpoint
 #' @param base_size base size for text in plot ; default is 12
 #'
@@ -19,50 +19,46 @@
 #' exons <- readRDS(system.file("extdata", "exonsToPlot.RDS", package = "annoFuse"))
 #' bioMartDataPfam <- readRDS(system.file("extdata", "pfamDataBioMart.RDS", package = "annoFuse"))
 #' domainDataFrame <- get_Pfam_domain(standardFusioncalls = standardFusioncalls, bioMartDataPfam = bioMartDataPfam, keepPartialAnno = TRUE)
-#' left <- plot_breakpoints(sampleid = "BS_044XZ8ST",domainDataFrame = domainDataFrame,exons = exons,geneposition = "Left",fusionname = "ANTXR1--BRAF")
-#' right <- plot_breakpoints(sampleid = "BS_044XZ8ST",domainDataFrame = domainDataFrame,exons = exons,geneposition = "Right",fusionname = "ANTXR1--BRAF")
-#' ggpubr::ggarrange(left,right,align = "h")
-#' 
-#' 
+#' left <- plot_breakpoints(sampleid = "BS_044XZ8ST", domainDataFrame = domainDataFrame, exons = exons, geneposition = "Left", fusionname = "ANTXR1--BRAF")
+#' right <- plot_breakpoints(sampleid = "BS_044XZ8ST", domainDataFrame = domainDataFrame, exons = exons, geneposition = "Right", fusionname = "ANTXR1--BRAF")
+#' ggpubr::ggarrange(left, right, align = "h")
 plot_breakpoints <- function(domainDataFrame = NULL,
                              exons = exons,
                              geneposition = NULL,
                              sampleid = NULL,
                              fusionname = NULL,
-                             leftBreakpoint = NULL ,
+                             leftBreakpoint = NULL,
                              rightBreakpoint = NULL,
-                             base_size = 12 ) {
-  if( is.null(domainDataFrame)){
+                             base_size = 12) {
+  if (is.null(domainDataFrame)) {
     stop("domainDataFrame not provide; please provide output from get_Pfam_domain() ")
   } else {
-    
-  if ( is.null(fusionname) ){
-    warning("FusionName not provide; using first row of domainDataFrame")
-  } else {
-    # subset the dataframe with domain information to only fusionname
-  domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$FusionName == fusionname), ] 
-  domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$FusionName == fusionname), ]
-  }
-    
-  if(nrow(domainDataFrame$Gene1B)==0 | nrow(domainDataFrame$Gene1A)==0 ) {
-    stop("domainDataFrame is empty after selecting for fusionname ")
-  } 
-  
-  if (!is.null(sampleid) ){
-    domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$Sample %in% sampleid), ] 
-    domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$Sample %in% sampleid), ] 
+    if (is.null(fusionname)) {
+      warning("FusionName not provide; using first row of domainDataFrame")
+    } else {
+      # subset the dataframe with domain information to only fusionname
+      domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$FusionName == fusionname), ]
+      domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$FusionName == fusionname), ]
+    }
+
+    if (nrow(domainDataFrame$Gene1B) == 0 | nrow(domainDataFrame$Gene1A) == 0) {
+      stop("domainDataFrame is empty after selecting for fusionname ")
+    }
+
+    if (!is.null(sampleid)) {
+      domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$Sample %in% sampleid), ]
+      domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$Sample %in% sampleid), ]
+    }
+
+    if (!is.null(leftBreakpoint)) {
+      domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$LeftBreakpoint == leftBreakpoint), ]
+    }
+    if (!is.null(rightBreakpoint)) {
+      domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$RightBreakpoint == rightBreakpoint), ]
+    }
   }
 
-  if (!is.null(leftBreakpoint)){
-    domainDataFrame$Gene1B <- domainDataFrame$Gene1B[which(domainDataFrame$Gene1B$LeftBreakpoint == leftBreakpoint), ] 
-  }
-  if (!is.null(rightBreakpoint)){
-    domainDataFrame$Gene1A <- domainDataFrame$Gene1A[which(domainDataFrame$Gene1A$RightBreakpoint == rightBreakpoint), ] 
-  }
-
-  }
-  
-  if (base_size != 12 ){
+  if (base_size != 12) {
     base_size <- base_size
   }
 
@@ -92,7 +88,7 @@ plot_breakpoints <- function(domainDataFrame = NULL,
       ggtitle(paste0(geneposition, " fused Gene:", gene)) +
       labs(fill = "Domain")
   }
-  
+
   if (geneposition == "Right") {
     geneExons <- exons[which(exons$geneName %in% unique(domainDataFrame$Gene1B$Gene1B)), ]
     # merge domain and exon annotation to plot
@@ -120,9 +116,9 @@ plot_breakpoints <- function(domainDataFrame = NULL,
 
   # add domain level information
   if (!all(is.na(geneExons$DESC))) {
-    p1 <- p1 + geom_linerange(ymin = geneExons$domain_start, ymax = geneExons$domain_end, size = 6, aes(col = geneExons$DESC, x = gene)) + labs(color = "Domain") +theme(legend.position = "bottom") + 
+    p1 <- p1 + geom_linerange(ymin = geneExons$domain_start, ymax = geneExons$domain_end, size = 6, aes(col = geneExons$DESC, x = gene)) + labs(color = "Domain") + theme(legend.position = "bottom") +
       ggplot2::scale_colour_discrete(na.translate = F)
-  }  
+  }
 
   # add direction of strand
   if (any(geneExons$strand.x == "+")) {
@@ -132,5 +128,4 @@ plot_breakpoints <- function(domainDataFrame = NULL,
   }
 
   return(p2)
-  
 }

--- a/man/annoFuse_single_sample.Rd
+++ b/man/annoFuse_single_sample.Rd
@@ -45,5 +45,24 @@ Standardized fusion calls annotated with gene list and fusion list provided in r
 Performs artifact filter to remove readthroughs,red flags and performs expression filtering with user provided expression Matrix and expression threshold
 }
 \examples{
-# TODOTODO
+standardFusioncalls <- annoFuse::annoFuse_single_sample(
+# Example files are provided in extdata, at-least 1 fusionfile is required along with it's rsem expression file
+fusionfileArriba = system.file("extdata", "arriba_example.tsv", package = "annoFuse"),
+fusionfileStarFusion = system.file("extdata", "starfusion_example.tsv", package = "annoFuse"),
+expressionFile = system.file("extdata", "example.rsem.genes.results.gz", package = "annoFuse"),
+tumorID = "BS_W97QQYKQ",
+# multiple read flag values for filtering using FusionAnnotator values
+artifactFilter = "GTEx_Recurrent|DGD_PARALOGS|Normal|BodyMap|ConjoinG",
+# keep all in-frame , frameshift and other types of Fusion_Type
+readingFrameFilter = "in-frame|frameshift|other",
+# keep all fusions with atleast 1 junction read support
+junctionReadCountFilter = 1,
+# keep only fusions where spanningFragCount-junctionReadCountFilter less than equal to 10
+spanningFragCountFilter = 10,
+# keep read throughs
+readthroughFilter = FALSE
+)
+
+
+
 }

--- a/man/plot_breakpoints.Rd
+++ b/man/plot_breakpoints.Rd
@@ -5,17 +5,32 @@
 \title{Function to plot breakpoints of a gene in a sample/cohort}
 \usage{
 plot_breakpoints(
-  domainDataFrame = domainDataFrame,
+  domainDataFrame = NULL,
   exons = exons,
-  geneposition = geneposition
+  geneposition = NULL,
+  sampleid = NULL,
+  fusionname = NULL,
+  leftBreakpoint = NULL,
+  rightBreakpoint = NULL,
+  base_size = 12
 )
 }
 \arguments{
 \item{domainDataFrame}{A dataframe from star fusion or arriba standardized to run through the filtering steps and get_Pfam_domain() function to get pfam domain annotation per gene}
 
-\item{exons}{exon level information from gtf}
+\item{exons}{exon level information from gtf availbale in the package exonsToPlot.RDS}
 
-\item{geneposition}{Left/Right position of gene}
+\item{geneposition}{Position of gene in the fusion allowed values are Left (Gene1A) or Right (Gene1B)}
+
+\item{sampleid}{id (if multiple provide a character vector) from Sample column of standardized fusion file format}
+
+\item{fusionname}{value from FusionName column of standardized fusion file format (Gene1A--Gene1B)}
+
+\item{leftBreakpoint}{If a specific breakpoint needs to be plotted then provide genomic coordinate as LeftBreakpoint}
+
+\item{rightBreakpoint}{If a specific breakpoint needs to be plotted then provide genomic coordinate as RightBreakpoint}
+
+\item{base_size}{base size for text in plot ; default is 12}
 }
 \value{
 ggplot of gene and breakpoints
@@ -24,5 +39,14 @@ ggplot of gene and breakpoints
 Function to plot breakpoints of a gene in a sample/cohort
 }
 \examples{
-# TODOTODO
+standardFusionfile <- system.file("extdata", "PutativeOncogenicFusion.tsv", package = "annoFuse")
+standardFusioncalls <- readr::read_tsv(standardFusionfile)
+exons <- readRDS(system.file("extdata", "exonsToPlot.RDS", package = "annoFuse"))
+bioMartDataPfam <- readRDS(system.file("extdata", "pfamDataBioMart.RDS", package = "annoFuse"))
+domainDataFrame <- get_Pfam_domain(standardFusioncalls = standardFusioncalls, bioMartDataPfam = bioMartDataPfam, keepPartialAnno = TRUE)
+left <- plot_breakpoints(sampleid = "BS_044XZ8ST",domainDataFrame = domainDataFrame,exons = exons,geneposition = "Left",fusionname = "ANTXR1--BRAF")
+right <- plot_breakpoints(sampleid = "BS_044XZ8ST",domainDataFrame = domainDataFrame,exons = exons,geneposition = "Right",fusionname = "ANTXR1--BRAF")
+ggpubr::ggarrange(left,right,align = "h")
+
+
 }

--- a/vignettes/singleSampleRun.Rmd
+++ b/vignettes/singleSampleRun.Rmd
@@ -45,6 +45,7 @@ Additionally, in the vignette we annotate filtered fusion with pfam domains per 
 suppressPackageStartupMessages(library("annoFuse"))
 suppressPackageStartupMessages(library("dplyr"))
 suppressPackageStartupMessages(library("reshape2"))
+suppressPackageStartupMessages(library("ggplot2"))
 
 # Run annoFuse for Single sample with default expression filter and FusionAnnotator red flag artifact filter
 standardFusioncalls <- annoFuse::annoFuse_single_sample(
@@ -75,9 +76,6 @@ annDomain <- annoFuse::get_Pfam_domain(
   keepPartialAnno = TRUE
 )
 
-# plot BRAF breakpoint in sample for KIAA1549--BRAF fusion
-kiaabraf <- annDomain$Gene1B[which(annDomain$Gene1B$FusionName == "KIAA1549--BRAF" & annDomain$Gene1B$Gene1B == "BRAF"), ] %>% dplyr::filter(!is.na(DESC))
-
 # read in exonsToPlot with exon and gene boundaries from gencode.v27.primary_assembly.annotation.gtf.gz
 exons <- readRDS(system.file("extdata", "exonsToPlot.RDS", package = "annoFuse"))
 ```
@@ -85,7 +83,11 @@ exons <- readRDS(system.file("extdata", "exonsToPlot.RDS", package = "annoFuse")
 ## Plot breakpoint
 
 ```{r , fig.width=10, fig.height=5}
-plot_breakpoints(domainDataFrame = kiaabraf, exons = exons, geneposition = "Right") + theme_publication(base_size = 12)
+# plot BRAF breakpoint in sample for KIAA1549--BRAF fusion
+kiaa1549 <- plot_breakpoints(domainDataFrame = annDomain, exons = exons, geneposition = "Left",fusionname = "KIAA1549--BRAF" ,base_size = 12) 
+braf <- plot_breakpoints(domainDataFrame = annDomain, exons = exons, geneposition = "Right",fusionname = "KIAA1549--BRAF"  , base_size = 12) 
+
+ggpubr::ggarrange(kiaa1549,braf,align = "h")
 ```
 
 

--- a/vignettes/singleSampleRun.Rmd
+++ b/vignettes/singleSampleRun.Rmd
@@ -84,10 +84,10 @@ exons <- readRDS(system.file("extdata", "exonsToPlot.RDS", package = "annoFuse")
 
 ```{r , fig.width=10, fig.height=5}
 # plot BRAF breakpoint in sample for KIAA1549--BRAF fusion
-kiaa1549 <- plot_breakpoints(domainDataFrame = annDomain, exons = exons, geneposition = "Left",fusionname = "KIAA1549--BRAF" ,base_size = 12) 
-braf <- plot_breakpoints(domainDataFrame = annDomain, exons = exons, geneposition = "Right",fusionname = "KIAA1549--BRAF"  , base_size = 12) 
+kiaa1549 <- plot_breakpoints(domainDataFrame = annDomain, exons = exons, geneposition = "Left", fusionname = "KIAA1549--BRAF", base_size = 12)
+braf <- plot_breakpoints(domainDataFrame = annDomain, exons = exons, geneposition = "Right", fusionname = "KIAA1549--BRAF", base_size = 12)
 
-ggpubr::ggarrange(kiaa1549,braf,align = "h")
+ggpubr::ggarrange(kiaa1549, braf, align = "h")
 ```
 
 


### PR DESCRIPTION
PR is related to #12 and #15 

- [x] add domain legend to the bottom ( internal to annoFuse ) 
- [x] add filtering inside the plot_breakpoint()
- [x] add Sample param to plot_breakpoint()
- [x] if non-coding genes in fusion add just gene and transcript structure 
- [x] For intergenic fusions, plots the breakpoint in the intergenic region closest to Gene1A or Gene1B
- [x] Removed "opt" from warning function

tested with KCNH1--AL590132.1,BRAF--ANTXR1 , LINC01019--LINC01019/IRX1 and KIAA1549--BRAF

In addition 
- [x] examples in plot_breakpoints and annoFuse_single_sample function calls 
- [x] vignette is updated with the new plot_breakpoint function call
