### PR TITLE
remove demo columns not in putative oncogenic release file

### DIFF
--- a/R/shinyFuse.R
+++ b/R/shinyFuse.R
@@ -323,6 +323,17 @@ shinyFuse <- function(out_annofuse = NULL) {
             } else {
               ""
             },
+            if ("Confidence" %in% colnames(values$annofuse_tbl)) {
+              selectInput(
+                inputId = "filter_confidence",
+                label = "Filter for confidence",
+                choices = c("", unique(values$annofuse_tbl$Confidence)),
+                selectize = TRUE, multiple = TRUE,
+                selected = unique(values$annofuse_tbl$Confidence)
+              )
+            } else {
+              ""
+            },
             if ("BreakpointLocation" %in% colnames(values$annofuse_tbl)) {
               selectInput(
                 inputId = "filter_bplocation",
@@ -330,6 +341,26 @@ shinyFuse <- function(out_annofuse = NULL) {
                 choices = c("", unique(values$annofuse_tbl$BreakpointLocation)),
                 selectize = TRUE, multiple = TRUE,
                 selected = unique(values$annofuse_tbl$BreakpointLocation)
+              )
+            } else {
+              ""
+            },
+            if ("SpanningFragCount" %in% colnames(values$annofuse_tbl)) {
+              numericInput(
+                inputId = "filter_spanningfragcount",
+                label = "Filter for spanning frag count",
+                value = 0,
+                min = 0, max = max(values$annofuse_tbl$SpanningFragCount)
+              )
+            } else {
+              ""
+            },
+            if ("JunctionReadCount" %in% colnames(values$annofuse_tbl)) {
+              numericInput(
+                inputId = "filter_junctionreadcount",
+                label = "Filter for junction read count",
+                value = 0,
+                min = 0, max = max(values$annofuse_tbl$JunctionReadCount)
               )
             } else {
               ""

--- a/R/shinyFuse.R
+++ b/R/shinyFuse.R
@@ -253,8 +253,7 @@ shinyFuse <- function(out_annofuse = NULL) {
           "Sample", "FusionName",
           "Gene1A", "Gene1B",
           "LeftBreakpoint", "RightBreakpoint",
-          "Fusion_Type", "JunctionReadCount", "SpanningFragCount",
-          "Confidence", "CalledBy"
+          "Fusion_Type", "CalledBy"
         )
         minset_cols <- minset_cols[minset_cols %in% all_cols]
 
@@ -324,17 +323,6 @@ shinyFuse <- function(out_annofuse = NULL) {
             } else {
               ""
             },
-            if ("Confidence" %in% colnames(values$annofuse_tbl)) {
-              selectInput(
-                inputId = "filter_confidence",
-                label = "Filter for confidence",
-                choices = c("", unique(values$annofuse_tbl$Confidence)),
-                selectize = TRUE, multiple = TRUE,
-                selected = unique(values$annofuse_tbl$Confidence)
-              )
-            } else {
-              ""
-            },
             if ("BreakpointLocation" %in% colnames(values$annofuse_tbl)) {
               selectInput(
                 inputId = "filter_bplocation",
@@ -342,26 +330,6 @@ shinyFuse <- function(out_annofuse = NULL) {
                 choices = c("", unique(values$annofuse_tbl$BreakpointLocation)),
                 selectize = TRUE, multiple = TRUE,
                 selected = unique(values$annofuse_tbl$BreakpointLocation)
-              )
-            } else {
-              ""
-            },
-            if ("SpanningFragCount" %in% colnames(values$annofuse_tbl)) {
-              numericInput(
-                inputId = "filter_spanningfragcount",
-                label = "Filter for spanning frag count",
-                value = 0,
-                min = 0, max = max(values$annofuse_tbl$SpanningFragCount)
-              )
-            } else {
-              ""
-            },
-            if ("JunctionReadCount" %in% colnames(values$annofuse_tbl)) {
-              numericInput(
-                inputId = "filter_junctionreadcount",
-                label = "Filter for junction read count",
-                value = 0,
-                min = 0, max = max(values$annofuse_tbl$JunctionReadCount)
               )
             } else {
               ""


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose/implementation Section

#### What feature is being added or bug is being addressed?
I am removing the below columns, which are no longer in our putative oncogenic release file, from the demo display.
"Caller"               "JunctionReadCount"    "SpanningFragCount"    "Confidence"  


#### What was your approach?
Is this sufficient for display and for there to be no errors when we add the new file over in annoFuseData? ie. do any of these need to be removed from ifelse? New file in PR [here](https://github.com/d3b-center/annoFuseData/pull/9)


#### What GitHub issue does your pull request address?
NA


### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?



#### Is there anything that you want to discuss further?


#### Documentation Checklist

<!-- Please review and specify if it isn't applicable -->

- [ ] The function has examples to showcase the usage 
- [ ] The function is fully documented in the package using roxygen 
- [ ] Added a vignette

#### Package Checklist

<!-- Check all those that apply or remove this section if it is not applicable.-->

- [ ] The dependencies required for the function in this pull request have been added to [DESCRIPTION](https://github.com/d3b-center/annoFuse/blob/master/DESCRIPTION) `Imports` section, and the corresponding `NAMESPACE` directives have been added/updated
- [ ] The files needed for the function to run are in `inst/extdata`
- [ ] The code was run through `styler` 


